### PR TITLE
Fix attempt to index a nil value global 'lib'

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -8,7 +8,8 @@ shared_scripts {
 	'@qb-core/shared/locale.lua',
 	'locales/en.lua',
 	'locales/*.lua',
-	'config.lua'
+	'config.lua',
+	'@ox_lib/init.lua'
 }
 
 client_script {


### PR DESCRIPTION
This fixes the "attempt to index a nil value global 'lib' at line 505 of client/main.lua

## Description

This pull request fixes the following issue:
![image](https://github.com/Qbox-project/qbx-garbagejob/assets/26857315/b65ae117-c944-4974-a8ed-c7e92ea8594d)


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
