### PR TITLE
fix(server): vehiclekeys not working

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           capture: "junit.xml"
           args: "-t --formatter JUnit"
-          extra_libs: mysql+polyzone+qblocales
+          extra_libs: mysql+polyzone+qblocales+ox_lib
       - name: Generate Lint Report
         if: always()
         uses: mikepenz/action-junit-report@v3

--- a/server/main.lua
+++ b/server/main.lua
@@ -102,7 +102,7 @@ lib.callback.register('garbagejob:server:spawnVehicle', function(source, coords)
     local veh = NetworkGetEntityFromNetworkId(netId)
     if not veh or veh == 0 then return end
 
-    local plate = "QB-" .. tostring(math.random(1000, 9999))
+    local plate = "GBGE" .. tostring(math.random(1000, 9999))
     SetVehicleNumberPlateText(veh, plate)
     TriggerClientEvent('vehiclekeys:client:SetOwner', source, plate)
     SetVehicleDoorsLocked(veh, 2)


### PR DESCRIPTION
## Description

Fix vehiclekeys not working when spawning garbage trucks (apparently the `-` in the plate was the issue).

Fixes #6.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
