### PR TITLE
feat(server): Notify client of stops left

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -33,7 +33,8 @@
         "found_crypto": "وجدت شيء ما",
         "payout_deposit": "(+ $%s الوديعة)",
         "store_truck":  "~g~E~w~ - ﺔﻣﺎﻤﻘﻟﺍ ﺔﻨﺣﺎﺷ ﻦﻳﺰﺨﺗ",
-        "get_truck":  "~g~E~w~ - ﺔﻣﺎﻤﻘﻟﺍ ﺔﻨﺣﺎﺷ"
+        "get_truck":  "~g~E~w~ - ﺔﻣﺎﻤﻘﻟﺍ ﺔﻨﺣﺎﺷ",
+        "stops_left": "You have %s stops left!"
     },
     "warning": {}
 }

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -48,6 +48,7 @@
         "store_truck": "[E] - Uložit odpadkový vůz",
         "get_truck": "[E] - Odpadkový vůz",
         "picking_bag": "Vybírání pytle na odpadky..",
-        "talk": "[E] Promluvit si s odpadkovým mužem"
+        "talk": "[E] Promluvit si s odpadkovým mužem",
+        "stops_left": "You have %s stops left!"
     }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -33,7 +33,8 @@
         "found_crypto": "Du hast einen Kryptostick auf dem Boden gefunden",
         "payout_deposit": "(+ $%s eingelagert)",
         "store_truck": "~g~E~w~ - Müllwagen Einparken",
-        "get_truck": "~g~E~w~ - Müllwagen"
+        "get_truck": "~g~E~w~ - Müllwagen",
+        "stops_left": "You have %s stops left!"
     },
     "warning": {}
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -48,6 +48,7 @@
         "store_truck": "[E] - Store Garbage Truck",
         "get_truck": "[E] - Garbage Truck",
         "picking_bag": "Grabbing garbage bag..",
-        "talk": "[E] Talk to Garbage Man"
+        "talk": "[E] Talk to Garbage Man",
+        "stops_left": "You have %s stops left!"
     }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -48,7 +48,8 @@
         "store_truck": "[E] - Almacenar camión de basura",
         "get_truck": "[E] - Camión de la basura",
         "picking_bag": "Agarrando bolsa de basura..",
-        "talk": "[E] Hablar con el hombre de la basura"
+        "talk": "[E] Hablar con el hombre de la basura",
+        "stops_left": "You have %s stops left!"
     },
     "warning": {}
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -48,6 +48,7 @@
         "store_truck": "[E] - Garer le Camion Benne",
         "get_truck": "[E] - Sortir un Camion Benne",
         "picking_bag": "Ramassage du sac poubelle...",
-        "talk": "[E] Parler avec l'éboueur"
+        "talk": "[E] Parler avec l'éboueur",
+        "stops_left": "You have %s stops left!"
     }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -33,7 +33,8 @@
         "found_crypto": "Hai trovato una cryptostick!",
         "payout_deposit": "(+ $%s di cauzione)",
         "store_truck": "[E] - Deposita camion",
-        "get_truck": "[E] - Camion della spazzatura"
+        "get_truck": "[E] - Camion della spazzatura",
+        "stops_left": "You have %s stops left!"
     },
     "warning": {}
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -48,7 +48,8 @@
         "store_truck": "[E] - Vuilniswagen retourneren",
         "get_truck": "[E] - Vuilniswagen",
         "picking_bag": "Vuilniszak oppakken..",
-        "talk": "[E] Praat ment Vuilnisman"
+        "talk": "[E] Praat ment Vuilnisman",
+        "stops_left": "You have %s stops left!"
     },
     "warning": {}
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -48,6 +48,7 @@
         "store_truck": "[E] - Guardar Camião de Lixo",
         "get_truck": "[E] - Camião de Lixo",
         "picking_bag": "A agarrar saco de lixo..",
-        "talk": "[E] Falar com o Lixieiro"
+        "talk": "[E] Falar com o Lixieiro",
+        "stops_left": "You have %s stops left!"
     }
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -48,7 +48,8 @@
         "store_truck": "[E] - Çöp Kamyonunu Depola",
         "get_truck": "[E] - Çöp Kamyonu",
         "picking_bag": "Çöp Torbası alınıyor..",
-        "talk": "[E] Çöpçü ile konuş"
+        "talk": "[E] Çöpçü ile konuş",
+        "stops_left": "You have %s stops left!"
     },
     "warning": {}
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -41,6 +41,9 @@ lib.callback.register('garbagejob:server:newShift', function(source, continue)
         shouldContinue = true
         totalNumberOfStops = #allStops
         bagNum = allStops[1].bags
+
+        -- Notify the player about the total number of stops left.
+        exports.qbx_core:Notify(source, (locale('info.stops_left'):format(totalNumberOfStops)), 'info')
     else
         exports.qbx_core:Notify(source, (locale('error.not_enough'):format(sharedConfig.truckPrice)), 'error')
     end
@@ -81,6 +84,11 @@ lib.callback.register('garbagejob:server:nextStop', function(source, currentStop
 
             routes[citizenId].actualPay = math.ceil(routes[citizenId].actualPay + totalNewPay)
             routes[citizenId].stopsCompleted = tonumber(routes[citizenId].stopsCompleted) + 1
+
+            -- Notify the player about the number of stops left
+            local stopsLeft = #routes[citizenId].stops - routes[citizenId].stopsCompleted
+            exports.qbx_core:Notify(source, (locale('info.stops_left'):format(stopsLeft)), 'info')
+
         end
     else
         exports.qbx_core:Notify(source, locale('error.too_far'), 'error')


### PR DESCRIPTION
## Description
feat: Added notification for the number of stops left.

Added a notification after every stop to inform the player about the number of stops left in their route. 
Added the English locale to every language, all others will need to be updated.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
