### PR TITLE
feat(garbagejob): add player reward system and difficulty multiplier

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -142,6 +142,7 @@ local function DeliverAnim()
                 SetGarbageRoute()
                 exports.qbx_core:Notify(locale('info.all_bags'))
                 SetVehicleDoorShut(garbageVehicle, 5, false)
+                TriggerServerEvent('qbx_garbagejob:server:givePlayerReward')
             else
                 if hasMoreStops and nextStop == currentStop then
                     exports.qbx_core:Notify(locale('info.depot_issue'))

--- a/config/server.lua
+++ b/config/server.lua
@@ -7,5 +7,6 @@ return {
     bagUpperWorth = 100,
     bagLowerWorth = 50,
     minBagsPerStop = 2,
-    maxBagsPerStop = 5
+    maxBagsPerStop = 5,
+    rewardItems = {'rubber', 'plastic'}
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 
 description 'QBX_GarbageJob'
 repository 'https://github.com/Qbox-project/qbx_garbagejob'
-version '1.0.0'
+version '1.1.0'
 
 ox_lib 'locale'
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -130,7 +130,7 @@ RegisterNetEvent('garbagejob:server:payShift', function(continue)
         if continue then
             depositPay = 0
         end
-        local totalToPay = depositPay + routes[citizenId].actualPay
+        local totalToPay<const> = (depositPay + routes[citizenId].actualPay) * exports.lenix_jobcenter:GetPlayerDifficultyMultiplier(citizenId, 'garbage')
         local payoutDeposit = locale('info.payout_deposit', depositPay)
         if depositPay == 0 then
             payoutDeposit = ''
@@ -142,6 +142,24 @@ RegisterNetEvent('garbagejob:server:payShift', function(continue)
     else
         exports.qbx_core:Notify(source, locale('error.never_clocked_on'), 'error')
     end
+end)
+
+
+RegisterNetEvent('qbx_garbagejob:server:givePlayerReward', function()
+    local playerData<const> = exports.qbx_core:GetPlayer(source).PlayerData
+    local playerLevel<const> = exports.lenix_jobcenter:GetPlayerLevel(playerData.citizenid, 'garbage')
+    local itemIndex<const> = math.random(1, 2)
+    local items<const> = config.rewardItems
+    if playerLevel >= 20 and playerLevel < 30 then
+        exports.ox_inventory:AddItem(source, items[itemIndex], math.random(1, 2))
+    else
+        if playerLevel >= 30 and playerLevel < 40 then
+            exports.ox_inventory:AddItem(source, items[itemIndex], math.random(2, 3))
+        else
+            exports.ox_inventory:AddItem(source, items[itemIndex], math.random(3, 5))
+        end
+    end
+    exports.lenix_jobcenter:GivePlayerRep(source, playerData.citizenid, 'garbage', 'lowend')
 end)
 
 lib.addCommand('cleargarbroutes', {


### PR DESCRIPTION
## Description
- Trigger reward event after garbage delivery in client script
- Add rewardItems configuration with 'rubber' and 'plastic'
- Apply player difficulty multiplier to payout calculation on server
- Implement server event to give item rewards based on player level
- Grant player reputation after rewarding items in garbage job context

## Checklist
- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
